### PR TITLE
feat: add configurable working directory for poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,22 @@ jobs:
       with:
         version: "1.1"
         extras: "foo bar baz"
+        directory: "./app"
 
     - name: run tests
       run: poetry run pytest
+      working-directory: "./app"
 ```
 
 ## 🎓 Usage
 
 ### Inputs
 
-| name      | default   | description                         |
-| --------- | --------- | ----------------------------------- |
-| `version` | `1.2.0b2` | the poetry version to install / use |
-| `extras`  | -         | any package extras to install       |
+| name          | default  | description                          |
+| -------------| --------- | ------------------------------------ |
+| `version`    | `1.2.0b2` | the poetry version to install / use  |
+| `extras`     | -         | any package extras to install        |
+| `directory`  | `.`       | the working directory to install use |
 
 ## 📚 Help
 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,12 @@ inputs:
     type: "string"
     required: false
 
+  directory:
+    description: "working directory of the project"
+    type: "string"
+    required: false
+    default: "."
+
   extras: 
     description: "python extras to install"
     type: "string"
@@ -35,15 +41,18 @@ runs:
     - name: set up cache
       uses: actions/cache@v3
       with:
-        path: .venv
-        key: venv-${{ hashFiles('**/poetry.lock') }}-${{ inputs.extras }}
+        path: ${{ inputs.directory }}/.venv
+        key: venv-${{ hashFiles('**/poetry.lock') }}-${{ inputs.extras }}-${{ inputs.directory }}
       id: cache
 
     - name: ensure cache is healthy
       run: timeout 10s poetry run pip --version || rm -rf .venv
       shell: bash
+      working-directory: ${{ inputs.directory }}
       if: steps.cache.outputs.cache-hit == 'true'
 
     - name: install dependencies
       run: poetry install ${{ inputs.extras && format('--extras "{0}"', inputs.extras) }}
       shell: bash
+      working-directory: ${{ inputs.directory }}
+


### PR DESCRIPTION
Fixes #2 

## Description

Adds an optional `directory` input to set the working directory of the install.


## Motivation and Context

At the moment the action cannot be used unless the code is located in the root of the repository, when the code is located in a sub-directory then the action will fail.

## How Has This Been Tested?

Tested the branch with a separate repository, and the correct folder was used for the poetry install.

A side-effect of modifying the cache key is that all existing caches have been invalidated but this is not a critical issue.

## Types of changes
<!--- 
What types of changes does your code introduce? Put an `x` in all the boxes that apply: 
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- 
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! 
-->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
